### PR TITLE
Query didn't use property without arguments to sort.

### DIFF
--- a/src/Morph/Query.php
+++ b/src/Morph/Query.php
@@ -162,7 +162,7 @@ class Morph_Query implements Morph_IQuery
 	    if (count($this->criteria) > 0) {
             foreach ($this->criteria as $propertyName => $criteria) {
                 $constraints = $criteria->getConstraints();
-                if (isset($constraints)) {
+                if (isset($constraints) && null !== $criteria->getMode()) {
                     $query[$propertyName] = $constraints;
                 }
             }

--- a/src/Morph/Query/Property.php
+++ b/src/Morph/Query/Property.php
@@ -340,6 +340,16 @@ class Morph_Query_Property implements Morph_IQuery
         return $this->sortDirection;
     }
 
+    /**
+     * Returns the mode of this property
+     *
+     * @return string
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
     //////////////////////////////////////////
     // INTERNAL CONSTRAINT HELPER FUNCTIONS //
     //////////////////////////////////////////

--- a/unit-tests/TestQuery.php
+++ b/unit-tests/TestQuery.php
@@ -76,5 +76,15 @@ class TestQuery extends PHPUnit_Framework_TestCase
         $this->assertEquals(12, $query->getSkip());
         $this->assertEquals(array('bob'=>1), $query->getRawSort());
     }
+
+    public function testSort()
+    {
+        $query = new Morph_Query();
+        $query->property('id')
+            ->equals(12)
+            ->property('added')
+            ->sort(Morph_Enum::DIRECTION_DESC);
+
+        $this->assertArrayNotHasKey('added', $query->getRawQuery());
+    }
 }
-?>


### PR DESCRIPTION
not sure that this solution is correct, but for me it works.
Situation: I have the comments table and need to sort entries by date created.
Please, review this solution.
