### PR TITLE
created loadByObjectId() and bugfixes in ComposeMany

### DIFF
--- a/make_phar.php
+++ b/make_phar.php
@@ -27,4 +27,4 @@ $phar->buildFromDirectory($src_dir);
 $phar->setStub(file_get_contents($src_dir . '..' . DIRECTORY_SEPARATOR . 'bootstrap.php'));
 $phar->setMetadata($metadata);
 $phar->compressFiles(Phar::GZ);
-echo "All done!";
+echo "All done!\n";

--- a/src/morph/Object.php
+++ b/src/morph/Object.php
@@ -221,6 +221,7 @@ class Object
 
     /**
      * Attempts to load the current object with data from the document id specified
+     * this is meant for if the _id is not necessarily an ObjectId
      *
      * @param mixed $id
      * @return Morph_Object
@@ -229,6 +230,18 @@ class Object
     {
         return Storage::instance()->fetchById($this, $id);
     }
+	
+    /**
+     * Attempts to load the current object with data from the document id specified
+     * This is meant for if the _id is a ObjectId 
+     *
+     * @param mixed $id
+     * @return Morph_Object
+     */
+	public function loadByObjectId($id) 
+	{
+	    return Storage::instance()->fetchByObjectId($this, $id);
+	}
 
     /**
      * Fetch multiple objects by their ids
@@ -295,7 +308,6 @@ class Object
 
 	// iterate through all the properties this object has and print them out
         foreach ($this->propertySet as $name => $property) {
-
             $data[$name] = (string)$property;
 	}
 

--- a/src/morph/Storage.php
+++ b/src/morph/Storage.php
@@ -94,6 +94,7 @@ class Storage
 	/**
 	 * Retrieves the contents of the specified $id
 	 * and assigns them into $object
+	 * This shoudld be used if the _id is not necessarily a ObjectId() (or the php version, MongoId() )
 	 *
 	 * @param Morph\\Object $object
 	 * @param mixed $id
@@ -104,6 +105,25 @@ class Storage
 		$query = array('_id' => $id);
 		$data = $this->db->selectCollection($object->collection())->findOne($query);
         return $this->setData($object, $data);
+	}
+	
+	/**
+	 * Retrieves the contents of the specified $id
+	 * and assigns them into $object
+	 * This function is meant for if the _id is a ObjectId (the default)
+	 *
+	 * @param Morph\\Object $object
+	 * @param mixed $id
+	 * @return Morph\\Object
+	 */
+	public function fetchByObjectId(Object $object, $id) {
+	
+		$objId = new \MongoId($id);
+	
+		$query = array('_id' => $objId);
+		$data = $this->db->selectCollection($object->collection())->findOne($query);
+        return $this->setData($object, $data);
+	
 	}
 
 	/**

--- a/src/morph/property/ComposeMany.php
+++ b/src/morph/property/ComposeMany.php
@@ -52,7 +52,7 @@ class  ComposeMany extends Generic
      * @see tao/classes/Morph/property/Morph_Property_Generic#setValue()
      */
     public function setValue($value){
-        if ($value->count() > 0) {
+        if (count($value) > 0) {
             foreach ($value as $object) {
                 $this->isPermissableType($object);
             }
@@ -84,7 +84,7 @@ class  ComposeMany extends Generic
     public function __getRawValue()
     {
         $rawValue = array();
-        if($this->value->count() > 0){
+        if(count($this->value) > 0){
             //$rawValue = $this->Value->getArrayCopy();
             foreach ($this->value as $value) {
                 $rawValue[] = $value->__getData();
@@ -92,8 +92,8 @@ class  ComposeMany extends Generic
         }
         return $rawValue;
     }
-    
-	/**
+
+    /**
      * @return string
      */
     public function __toString()


### PR DESCRIPTION
Since i spent...quite a few hours figuring out why i could not find something in the database by its ID, i found out that there was a class given to you by the mongo php driver called MongoID which is what you wrap the hex string in to find a document by its id. I then created loadByObjectId() so you can just pass in the hex string and you don't have to remember to put your hex string into a MongoId object. But the old loadById() should be kept since keys can be anything apparently

and ComposeMany kept throwing warnings that count() was being called on a non object, so i just replaced $value->count() with count($value), and it seems to be working fine
