### PR TITLE
deleteByQuery(...) function was added, so its possible to delete multiple documents based on a query

### DIFF
--- a/src/morph/Object.php
+++ b/src/morph/Object.php
@@ -249,6 +249,18 @@ class Object
     {
         return Storage::instance()->findByQuery($this, $query);
     }
+    
+    /**
+     * Deletes objects by query
+     *
+     * @param  IQuery $query
+     * @param  bool $safe
+     * @return \morph\Iterator
+     */
+    public function deleteByQuery(IQuery $query, $safe = null)
+    {
+        return Storage::instance()->findByQuery($this, $query, $safe);
+    }
 
     /**
      * Finds one object by query

--- a/src/morph/Storage.php
+++ b/src/morph/Storage.php
@@ -207,6 +207,32 @@ class Storage
 		$query = array('_id' => $object->id());
 		return $this->db->selectCollection($object->collection())->remove($query, array('justOne' => true));
 	}
+	
+	/**
+	 * Deletes documents based on query
+	 *
+	 * The results come packages up in a \morph\Iterator object
+	 *
+	 * @param  Object $object Required to determine the correct collection query against
+	 * @param  IQuery $query
+	 * @param  bool $safe
+	 * @return bool
+	 */
+	public function deleteByQuery(Object $object, IQuery $query = null, $safe = null)
+	{
+		$class = get_class($object);
+
+		$query = (is_null($query)) ? new Query() : $query;
+		
+		$options = array();
+		if (!is_null($safe))
+		{
+			$options[] = array('safe' => $safe);
+		}
+
+		$rawQuery = $this->getRawQuery($object, $query);
+		return $this->db->selectCollection($object->collection())->remove($rawQuery, $options);
+	}
 
 	/**
 	 * Runs query against the database


### PR DESCRIPTION
I couldn't find any way to delete multiple items based on a query without looping through each document and calling delete(), so i added a deleteByQuery(..) function
