### PR TITLE
Feature/save only changes

### DIFF
--- a/src/morph/Object.php
+++ b/src/morph/Object.php
@@ -131,22 +131,34 @@ class Object
      *
      * @return array
      */
-    public function __getData()
+    public function __getData($whereNew = false)
     {
         $data = array();
         if (!is_null($this->id)) {
             $data['_id'] = $this->id;
         }
         $data['_ns'] = \get_class($this);
-        foreach($this->propertySet as $property) {
-        	$storageName = $this->propertySet->getStorageName($property->getName());
-            $data[$storageName] = $property->__getRawValue();
+        foreach ($this->propertySet as $property) {
+            $storageName = $this->propertySet->getStorageName($property->getName());
+
+            if (!$whereNew) {
+                $data[$storageName] = $property->__getRawValue();
+            } else {
+                $state = $property->getState();
+
+                if ($state === \morph\Enum::STATE_DIRTY || $state === \morph\Enum::STATE_NEW) {
+                    $data[$storageName] = $property->__getRawValue();
+                }
+            }
         }
+        var_dump($data);
         return $data;
     }
 
     /**
-     * @return \morph\PropertSet
+     * Returns the PropertySet for this object
+     * 
+     * @return \morph\PropertySet
      */
     public function __getPropertySet()
     {
@@ -158,6 +170,8 @@ class Object
     // ********************** //
 
     /**
+     * Gets a property by name if it exists. Issues an E_USER_WARNING if it does not exist.
+     * 
      * @param $propertyName
      * @return mixed
      */
@@ -173,6 +187,8 @@ class Object
     }
 
     /**
+     * Sets a property by name and value
+     * 
      * @param  string $propertyName
      * @param  string $propertyValue
      * @return \morph\Object

--- a/src/morph/Object.php
+++ b/src/morph/Object.php
@@ -129,6 +129,7 @@ class Object
     /**
      * Gets the property data for this object
      *
+     * @param  boolean  $whereNew  Whether or not to only get dirty/new properties.
      * @return array
      */
     public function __getData($whereNew = false)
@@ -151,7 +152,7 @@ class Object
                 }
             }
         }
-        var_dump($data);
+
         return $data;
     }
 

--- a/src/morph/PropertySet.php
+++ b/src/morph/PropertySet.php
@@ -77,7 +77,12 @@ class  PropertySet extends \ArrayObject
         }
         $this[$name]->__setRawValue($value, $state);
     }
-    
+
+    /**
+     * Gets the current state for the entire property set
+     * 
+     * @return string   A string that matches to a constant in \Morph\Enum
+     */
     public function getState()
     {
         $state = \morph\Enum::STATE_NEW;
@@ -104,7 +109,7 @@ class  PropertySet extends \ArrayObject
 
         return $state;
     }
-    
+
     /**
      * Sets a storage alias for the named property
      * 
@@ -156,7 +161,7 @@ class  PropertySet extends \ArrayObject
      */
     public function append($object)
     {
-        throw new \RuntimeException("Appending to PropertySet is not supported");
+        throw new \RuntimeException("Appending to morph\\PropertySet is not supported");
     }
 
     /**
@@ -184,7 +189,7 @@ class  PropertySet extends \ArrayObject
     private function checkType($object)
     {
         if (!\is_object($object)) {
-            throw new \InvalidArgumentException('value if not and object that extends Morph_Property_Generic');
+            throw new \InvalidArgumentException('value if not and object that extends morph\\property\\Generic');
         }
 
         if(!($object instanceof \morph\property\Generic)){


### PR DESCRIPTION
Hello, good tidings, and all that fun stuff!

I apologize in advance for borking the commits (merge into master from ... yadda), I tried to squash them into one and apparently I am not more of a git than git expects. But I digress.

Prior to now, Object::save() called Storage::save(), which ended up calling insert() no matter what. 

I added functionality to update, as well as changed the Object::__getData method to accept a param that only returns 'new' or 'dirty' data.

When Storage::update() is called, it gets all the new or changed data, and sends it off to MongoDB using $set.

The unfortunate side effect of this is that embedded documents do not use $push or $pull. I will be working on that in the future.
